### PR TITLE
Reduce num of DB connections used

### DIFF
--- a/etl_server_redeploy.yml
+++ b/etl_server_redeploy.yml
@@ -152,4 +152,5 @@
       data_pipeline_db_url: "jdbc:postgresql://{{ hostvars['localhost']['backend_postgres_endpoint'] }}:{{ hostvars['localhost']['backend_postgres_port'] }}/{{ backend_db_name }}"
       data_pipeline_db_username: "{{ backend_postgres_master_username }}"
       data_pipeline_db_password: "{{ backend_postgres_master_password }}"
+      #data_pipeline_loader_threads: (see group_vars/all/main.yml)
 

--- a/fhir_server_ami.yml
+++ b/fhir_server_ami.yml
@@ -88,6 +88,7 @@
         data_server_db_url: "jdbc:postgresql://{{ hostvars['localhost']['backend_postgres_endpoint'] }}:{{ hostvars['localhost']['backend_postgres_port'] }}/{{ backend_db_name }}"
         data_server_db_username: "{{ backend_postgres_master_username }}"
         data_server_db_password: "{{ backend_postgres_master_password }}"
+        #data_server_db_max_connections: (see group_vars/all/main.yml)
 
 - name: Configure AWS CloudWatch Logs Agent
   hosts: backend_fhir_master

--- a/fhir_servers_elb.yml
+++ b/fhir_servers_elb.yml
@@ -86,7 +86,7 @@
         health_check_type: 'EC2'
         min_size: "{{ ec2_asg_backend_fhir_target_count }}"
         desired_capacity: "{{ ec2_asg_backend_fhir_target_count }}"
-        max_size: 10  # Watch out that this (plus extra instances for next deploy) doesn't exceed the max allowed DB connections!
+        max_size: "{{ data_server_asg_max_size }}"
         replace_all_instances: true
         replace_batch_size: 1
         region: "{{ aws_region }}"

--- a/group_vars/all/main.yml
+++ b/group_vars/all/main.yml
@@ -35,16 +35,17 @@ backend_db_name: 'bluebutton_backend_sandbox'
 backend_fhir_port_internal: 8443
 backend_fhir_port_external: 443
 
-# 8x vCPUs, 32 GB RAM
+# 8x vCPUs, 32 GB RAM, 1065 max connections on Postgres 9.6 (per `select * from pg_settings where name='max_connections';`)
 rds_backend_db_instance_type: 'db.m4.2xlarge'
 
 # 16x vCPUs, 64 GB RAM.
-ec2_backend_fhir_instance_type: 'm4.4xlarge'
 ec2_backend_etl_instance_type: 'm4.4xlarge'
+ec2_backend_fhir_instance_type: 'm4.4xlarge'
+data_pipeline_jvm_args: '-Xmx58g'
+data_pipeline_loader_threads: 100  # The service will use x2 this number of DB connections.
 data_server_appserver_jvmargs: '-Xmx58g -XX:MaxMetaspaceSize=4g'
 data_server_db_max_connections: '100'
-data_pipeline_jvm_args: '-Xmx58g'
-data_pipeline_loader_threads: '390'
+data_server_asg_max_size: 7  # Watch out that this (plus extra instances for next deploy) doesn't exceed the max allowed DB connections!
 # When `true`, Ansible will configure the FHIR server to run such that Java
 # flame graphs can be collected. This will incur a performance penalty of 1%-
 # 3%, and so should be left disabled unless specifically needed.


### PR DESCRIPTION
These changes helped resolve an outage that occurred when we "flipped the switch" over to the new synthetic data. Some manual instance termination was also needed to recover at that time, but these changes should prevent any need to do that as part of future deploys.

Also refactored the configs so that, by looking in one place (the `group_vars/all/main.yml` file), a dev can figure out how many connections should be available and how many should be used.

https://issues.hhsdevcloud.us/browse/CBBI-305