### PR TITLE
Update CloudWatch metric filter formats for new access log fields

### DIFF
--- a/fhir_server_ami.yml
+++ b/fhir_server_ami.yml
@@ -116,10 +116,6 @@
 
   tasks:
 
-    - name: List Existing Metric Filters
-      command: aws logs describe-metric-filters --log-group-name bluebutton-sandbox-backend/data-server/access.log
-      register: command_list_aws_log_metrics
-
     - name: Create Filter Pattern Variable
       set_fact:
         filterPatternBase: '[remote_host_name, remote_logical_username, remote_authenticated_user, timestamp, timestamp_zone, request, query_string, status_code, bytes, duration_milliseconds, original_query_id, original_query_counter, original_query_timestamp, developer, developer_name, application_id, application, user_id, user, beneficiary_id]'
@@ -131,7 +127,6 @@
         --filter-name "{{ item.name }}"
         --filter-pattern "{{ item.filterPattern }}"
         --metric-transformations "metricName={{ item.name }},metricNamespace=bluebutton-sandbox-backend,metricValue={{ item.metricValue }}{{ '' if item.defaultValue == "" else ',defaultValue={0}'.format(item.defaultValue) }}"
-      when: "'\"filterName\": \"{0}\",'.format(item.name) not in command_list_aws_log_metrics.stdout"
       with_items:
         - { name: 'bluebutton-sandbox-backend/data-server/http-requests/count', metricValue: '1', defaultValue: '0',
             filterPattern: "{{ filterPatternBase }}" }

--- a/fhir_server_ami.yml
+++ b/fhir_server_ami.yml
@@ -120,6 +120,10 @@
       command: aws logs describe-metric-filters --log-group-name bluebutton-sandbox-backend/data-server/access.log
       register: command_list_aws_log_metrics
 
+    - name: Create Filter Pattern Variable
+      set_fact:
+        filterPatternBase: '[remote_host_name, remote_logical_username, remote_authenticated_user, timestamp, timestamp_zone, request, query_string, status_code, bytes, duration_milliseconds, original_query_id, original_query_counter, original_query_timestamp, developer, developer_name, application_id, application, user_id, user, beneficiary_id]'
+
     - name: Set Metric Filter for Counting All Requests
       command: >
         aws logs put-metric-filter
@@ -130,17 +134,17 @@
       when: "'\"filterName\": \"{0}\",'.format(item.name) not in command_list_aws_log_metrics.stdout"
       with_items:
         - { name: 'bluebutton-sandbox-backend/data-server/http-requests/count', metricValue: '1', defaultValue: '0',
-            filterPattern: '[remote_host_name, remote_logical_username, remote_authenticated_user, timestamp, timestamp_zone, request, query_string, status_code, bytes, duration_milliseconds]' }
+            filterPattern: "{{ filterPatternBase }}" }
         - { name: 'bluebutton-sandbox-backend/data-server/http-requests/count/not-http-2xx', metricValue: '1', defaultValue: '0',
-            filterPattern: '[remote_host_name, remote_logical_username, remote_authenticated_user, timestamp, timestamp_zone, request, query_string, status_code != 2*, bytes, duration_milliseconds]' }
+            filterPattern: "{{ filterPatternBase | regex_replace('status_code', 'status_code != 2\*') }}" }
         - { name: 'bluebutton-sandbox-backend/data-server/http-requests/latency', metricValue: '$duration_milliseconds', defaultValue: '',
-            filterPattern: '[remote_host_name, remote_logical_username, remote_authenticated_user, timestamp, timestamp_zone, request, query_string, status_code, bytes, duration_milliseconds]' }
+            filterPattern: "{{ filterPatternBase }}" }
         - { name: 'bluebutton-sandbox-backend/data-server/http-requests/latency/patient', metricValue: '$duration_milliseconds', defaultValue: '',
-            filterPattern: '[remote_host_name, remote_logical_username, remote_authenticated_user, timestamp, timestamp_zone, request = *Patient*, query_string, status_code, bytes, duration_milliseconds]' }
+            filterPattern: "{{ filterPatternBase | regex_replace('request', 'request = \*Patient\*') }}" }
         - { name: 'bluebutton-sandbox-backend/data-server/http-requests/latency/coverage', metricValue: '$duration_milliseconds', defaultValue: '',
-            filterPattern: '[remote_host_name, remote_logical_username, remote_authenticated_user, timestamp, timestamp_zone, request = *Coverage*, query_string, status_code, bytes, duration_milliseconds]' }
+            filterPattern: "{{ filterPatternBase | regex_replace('request', 'request = \*Coverage\*') }}" }
         - { name: 'bluebutton-sandbox-backend/data-server/http-requests/latency/eob', metricValue: '$duration_milliseconds', defaultValue: '',
-            filterPattern: '[remote_host_name, remote_logical_username, remote_authenticated_user, timestamp, timestamp_zone, request = *ExplanationOfBenefit*, query_string, status_code, bytes, duration_milliseconds]' }
+            filterPattern: "{{ filterPatternBase | regex_replace('request', 'request = \*ExplanationOfBenefit\*') }}" }
 
 - name: Convert FHIR Server Master to AMI
   hosts: localhost
@@ -169,4 +173,3 @@
         instance_ids: "{{ ec2_backend_fhir_master.instance_ids }}"
         region: "{{ aws_region }}"
       ignore_errors: true
-


### PR DESCRIPTION
Not using the fields at all (yet), just ensuring that the filters are complete/correct.

In fact, having done a bit of research, CloudWatch may not be capable of answering questions like "how many devs used the API today". It can store/track the data for it, but doesn't support those types of analysis. Bother...

https://issues.hhsdevcloud.us/browse/CBBF-103